### PR TITLE
feat: add support for operations on multiple sObjects to optimize roundtrips

### DIFF
--- a/force/client.go
+++ b/force/client.go
@@ -46,6 +46,12 @@ func (forceAPI *ForceAPI) Delete(path string, params url.Values) error {
 	return forceAPI.request("DELETE", path, params, nil, nil)
 }
 
+// DeleteWithResponse issues a DELETE to the specified path with the given payload
+// and put the unmarshalled (json) response in the third parameter.
+func (forceAPI *ForceAPI) DeleteWithResponse(path string, params url.Values, out interface{}) error {
+	return forceAPI.request("DELETE", path, params, nil, out)
+}
+
 func (forceAPI *ForceAPI) request(method, path string, params url.Values, payload, out interface{}) error {
 	if err := forceAPI.oauth.Validate(); err != nil {
 		return fmt.Errorf("Error creating %v request: %v", method, err)

--- a/force/sobjects.go
+++ b/force/sobjects.go
@@ -2,6 +2,7 @@ package force
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -138,6 +139,284 @@ func (forceAPI *ForceAPI) DeleteSObjectByExternalId(id string, in SObject) (err 
 		in.ExternalIDAPIName(), id)
 
 	err = forceAPI.Delete(uri, nil)
+
+	return
+}
+
+const (
+	soCreateBatchSize = 200
+	soUpdateBatchSize = 200
+	soDeleteBatchSize = 200
+)
+
+type SObjectRecordAttributes struct {
+	Type        string `json:"type,omitempty"`
+	ReferenceID string `json:"referenceId,omitempty"`
+	URL         string `json:"url,omitempty"`
+}
+
+type sObjectInsertMultipleReq struct {
+	Records []SObject `json:"records"`
+}
+
+type sObjectInsertMultipleResp struct {
+	HasErrors bool `json:"hasErrors"`
+	Results   []struct {
+		ID          string `json:"id"`
+		ReferenceID string `json:"referenceId"`
+	} `json:"results"`
+}
+
+// InsertMultipleSObjects creates multiple unrelated records of the same type in batches of maximum "soCreateBatchSize"
+// size.
+// An incoming `SObject` should have "attributes" property with of type `SObjectRecordAttributes`: `Type` and
+// `ReferenceID` should be filled out with corresponding SObject type (APIName) and some external ID.
+// Note: supported by Salesforce API v45.0 (Spring 2019) and later.
+//
+// Example:
+//
+//    type CustomObject struct {
+//      Name     string
+//      Value    int
+//      IsActive bool
+//
+//      Attributes SObjectRecordAttributes `json:"attributes"`
+//    }
+//
+//    func (_ CustomObject) APIName() string           { return "CustomObject__c" }
+//    func (_ CustomObject) ExternalIDAPIName() string { return "id" }
+//
+//    func foo() {
+//      o1 := CustomObject{Name: "object 1", Value: 100, IsActive: false}
+//      o1.Attributes = SObjectRecordAttributes{Type: o1.APIName(), ReferenceID: "1"}
+//
+//      o2 := CustomObject{Name: "object 2", Value: 200, IsActive: false}
+//      o2.Attributes = SObjectRecordAttributes{Type: o2.APIName(), ReferenceID: "2"}
+//
+//      objects := []CustomObject{o1, o2}
+//
+//      // Convert types.
+//      sObjects := make([]SObject, len(objects))
+//      for i := range objects {
+//        sObjects[i] = objects[i]
+//      }
+//      _ = forceAPI.InsertMultipleSObjects(sObjects)
+//    }
+//
+// See https://developer.salesforce.com/docs/atlas.en-us.218.0.api_rest.meta/api_rest/dome_composite_sobject_tree_flat.htm
+func (forceAPI *ForceAPI) InsertMultipleSObjects(in []SObject) (err error) {
+	if len(in) == 0 {
+		return nil
+	}
+
+	// Check sobject's types are the same.
+	soType := in[0].APIName()
+	for _, o := range in {
+		if o.APIName() != soType {
+			return errors.New("all objects should have the same type (APIName)")
+		}
+	}
+
+	// Check if requested sobject type exists in SF.
+	if _, ok := forceAPI.apiSObjects[soType]; !ok {
+		return fmt.Errorf("SObject type not found: %s", soType)
+	}
+
+	uri := fmt.Sprintf("/services/data/%s/composite/tree/%s", forceAPI.apiVersion, soType)
+
+	// Split all records to batches.
+	limit := soCreateBatchSize
+	for i := 0; i < len(in); i += limit {
+		end := i + limit
+		if end > len(in) {
+			end = len(in)
+		}
+
+		records := in[i:end]
+
+		req := sObjectInsertMultipleReq{Records: records}
+		var resp sObjectInsertMultipleResp
+		if err := forceAPI.Post(uri, nil, req, &resp); err != nil {
+			return fmt.Errorf("forceAPI.Post: %s", err)
+		}
+
+		if resp.HasErrors {
+			errRefIDs := []string{}
+			for _, r := range resp.Results {
+				errRefIDs = append(errRefIDs, r.ReferenceID)
+			}
+			return fmt.Errorf("error creating objects, refIDs: %s", strings.Join(errRefIDs, ", "))
+		}
+	}
+
+	return nil
+}
+
+type sObjectUpdateMultipleReq struct {
+	AllOrNone bool      `json:"allOrNone"`
+	Records   []SObject `json:"records"`
+}
+
+type sObjectUpdateMultipleResp []struct {
+	ID      string `json:"id"`
+	Success bool   `json:"success"`
+	Errors  []struct {
+		StatusCode string `json:"statusCode"`
+		Message    string `json:"message"`
+	} `json:"errors"`
+}
+
+// UpdateMultipleSObjects update multiple records of the arbitrary type in batches of maximum "soUpdateBatchSize"
+// size.
+// An incoming `SObject` should have "id" property with a valid ID value, and "attributes" property with of type
+// `SObjectRecordAttributes`: `Type` should be filled out with corresponding SObject type (APIName).
+// Note: supported by Salesforce API v43.0 (Summer 2018) and later.
+//
+// Example:
+//
+//    type CustomObject struct {
+//      ID 		 string `json:"id"`
+//      Name     string
+//      Value    int
+//      IsActive bool
+//
+//      Attributes SObjectRecordAttributes `json:"attributes"`
+//    }
+//
+//    func (_ CustomObject) APIName() string           { return "CustomObject__c" }
+//    func (_ CustomObject) ExternalIDAPIName() string { return "id" }
+//
+//    func foo() {
+//      o1 := CustomObject{ID: "id1", Name: "object 1", Value: 100, IsActive: false}
+//      o1.Attributes = SObjectRecordAttributes{Type: o1.APIName()}
+//
+//      o2 := CustomObject{ID: "id2", Name: "object 2", Value: 200, IsActive: false}
+//      o2.Attributes = SObjectRecordAttributes{Type: o2.APIName()}
+//
+//      objects := []CustomObject{o1, o2}
+//
+//      // Convert types.
+//      sObjects := make([]SObject, len(objects))
+//      for i := range objects {
+//        sObjects[i] = objects[i]
+//      }
+//      _ = forceAPI.UpdateMultipleSObjects(sObjects, true)
+//    }
+//
+// See https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_update.htm
+func (forceAPI *ForceAPI) UpdateMultipleSObjects(in []SObject, inTransaction bool) (err error) {
+	if len(in) == 0 {
+		return nil
+	}
+
+	// Check if requested sobject type exists in SF.
+	for _, o := range in {
+		soType := o.APIName()
+		if _, ok := forceAPI.apiSObjects[soType]; !ok {
+			return fmt.Errorf("SObject type not found: %s", soType)
+		}
+	}
+
+	uri := fmt.Sprintf("/services/data/%s/composite/sobjects", forceAPI.apiVersion)
+
+	// Split all records to batches.
+	limit := soUpdateBatchSize
+	for i := 0; i < len(in); i += limit {
+		end := i + limit
+		if end > len(in) {
+			end = len(in)
+		}
+
+		records := in[i:end]
+
+		req := sObjectUpdateMultipleReq{
+			AllOrNone: inTransaction,
+			Records:   records,
+		}
+		var resp sObjectUpdateMultipleResp
+		if err := forceAPI.Patch(uri, nil, req, &resp); err != nil {
+			return fmt.Errorf("forceAPI.Patch: %s", err)
+		}
+
+		// Check response, format errors.
+		var errs []string
+		for _, res := range resp {
+			if !res.Success {
+				codes := ""
+				for _, e := range res.Errors {
+					codes = fmt.Sprintf("%s, %s", codes, e.StatusCode)
+				}
+
+				errs = append(errs, fmt.Sprintf("%s: %s", res.ID, codes))
+			}
+		}
+
+		if len(errs) > 0 {
+			return fmt.Errorf("error updating objects: %s", strings.Join(errs, ", "))
+		}
+	}
+
+	return nil
+}
+
+type sObjectDeleteMultipleResp []struct {
+	ID      string `json:"id"`
+	Success bool   `json:"success"`
+	Errors  []struct {
+		StatusCode string `json:"statusCode"`
+		Message    string `json:"message"`
+	} `json:"errors"`
+}
+
+// DeleteMultipleSObjects deletes multiple sObjects by IDs in batches of maximum "soDeleteBatchSize" size.
+// `inTransaction` option controls if deletion of each batch should be performed in a single transaction.
+// Note: supported by Salesforce API v43.0 (Summer 2018) and later.
+// See https://developer.salesforce.com/docs/atlas.en-us.214.0.api_rest.meta/api_rest/resources_composite_sobjects_collections_delete.htm
+func (forceAPI *ForceAPI) DeleteMultipleSObjects(ids []string, inTransaction bool) (err error) {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	uri := fmt.Sprintf("/services/data/%s/composite/sobjects", forceAPI.apiVersion)
+
+	params := url.Values{}
+	if inTransaction {
+		params.Set("allOrNone", "true")
+	}
+
+	// Split all ids to batches.
+	limit := soDeleteBatchSize
+	for i := 0; i < len(ids); i += limit {
+		end := i + limit
+		if end > len(ids) {
+			end = len(ids)
+		}
+
+		batch := ids[i:end]
+		params.Set("ids", strings.Join(batch, ","))
+
+		var resp sObjectDeleteMultipleResp
+		if err := forceAPI.DeleteWithResponse(uri, params, &resp); err != nil {
+			return fmt.Errorf("forceAPI.Delete: %s", err)
+		}
+
+		// Check response, format errors.
+		var errs []string
+		for _, res := range resp {
+			if !res.Success {
+				codes := ""
+				for _, e := range res.Errors {
+					codes = fmt.Sprintf("%s, %s", codes, e.StatusCode)
+				}
+
+				errs = append(errs, fmt.Sprintf("%s: %s", res.ID, codes))
+			}
+		}
+
+		if len(errs) > 0 {
+			return fmt.Errorf("error deleting objects: %s", strings.Join(errs, ", "))
+		}
+	}
 
 	return
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/goguardian/go-force
+
+go 1.12


### PR DESCRIPTION
- `InsertMultipleSObjects`: Salesforce API v45.0+ https://developer.salesforce.com/docs/atlas.en-us.218.0.api_rest.meta/api_rest/dome_composite_sobject_tree_flat.htm
- `UpdateMultipleSObjects`: Salesforce API v43.0+ https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_update.htm
- `DeleteMultipleSObject`: Salesforce API v43.0+ https://developer.salesforce.com/docs/atlas.en-us.214.0.api_rest.meta/api_rest/resources_composite_sobjects_collections_delete.htm
- Add `go.mod`